### PR TITLE
Refactors and test creation to existing code.

### DIFF
--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -25,13 +25,7 @@ jobs:
 
       - name: Create config file
         run: |
-          echo '{
-              "request_origins": ["*"],
-              "server_ip": "0.0.0.0",
-              "server_port": 8080,
-              "using_chatbot": false,
-              "jwt_secret": "testing"
-          }' > Backend/app/server_config.json
+          echo '{"request_origins": ["*"], "server_ip": "0.0.0.0", "server_port": 8080, "using_chatbot": false, "jwt_secret": "testing"}' > Backend/app/server_config.json
 
       - name: Cache dependencies
         uses: actions/cache@v2
@@ -39,7 +33,7 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('Backend/**/*requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-${{ hashFiles('Backend/**/*requirements.txt') }}
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v3
@@ -54,4 +48,5 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest Backend/tests/
+          cd Backend
+          pytest tests/

--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -6,10 +6,11 @@ on:
       - main
     paths:
       - 'Backend/**/*.py'
+      - 'Backend/**/*requirements.txt'
   pull_request:
     paths:
       - 'Backend/**/*.py'
-
+      - 'Backend/**/*requirements.txt'
 
 jobs:
   test:
@@ -22,12 +23,19 @@ jobs:
       - name: Checks out repository
         uses: actions/checkout@v3
 
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('Backend/**/*requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -36,4 +44,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest Backend/test/
+          pytest Backend/tests/

--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -1,0 +1,39 @@
+name: Python Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Backend/**/*.py'
+  pull_request:
+    paths:
+      - 'Backend/**/*.py'
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      PYTHON_VERSION: "3.12"
+
+    steps:
+      - name: Checks out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f Backend/dev-requirements.txt ]; then pip install -r Backend/dev-requirements.txt; fi
+          if [ -f Backend/requirements.txt ]; then pip install -r Backend/requirements.txt; fi
+
+      - name: Test with pytest
+        run: |
+          pytest Backend/test/

--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -23,6 +23,16 @@ jobs:
       - name: Checks out repository
         uses: actions/checkout@v3
 
+      - name: Create config file
+        run: |
+          echo '{
+              "request_origins": ["*"],
+              "server_ip": "0.0.0.0",
+              "server_port": 8080,
+              "using_chatbot": false,
+              "jwt_secret": "testing"
+          }' > Backend/app/server_config.json
+
       - name: Cache dependencies
         uses: actions/cache@v2
         with:

--- a/Backend/app/ai/chatbot_router.py
+++ b/Backend/app/ai/chatbot_router.py
@@ -1,16 +1,21 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from app.ai.chatbot import Skynet
-from app.ai.topics import Topics
+from app.server_config import ServerConfig
 
 
 class QuestionRequest(BaseModel):
     question: str
 
 
-topics = Topics()
-skynet = Skynet(topics)
+config = ServerConfig()
+
+if config.is_using_chatbot():
+    from app.ai.chatbot import Skynet
+    from app.ai.topics import Topics
+
+    topics = Topics()
+    skynet = Skynet(topics)
 
 router = APIRouter(prefix="/chatbot", tags=["Chatbot"])
 
@@ -19,7 +24,11 @@ router = APIRouter(prefix="/chatbot", tags=["Chatbot"])
 async def chatbot_question(question_request: QuestionRequest):
     question = question_request.question
     print(f"Usuario: {question}")
-    answer = skynet.answer(question)
-    print(f"Chatbot: {answer}")
+
+    if config.is_using_chatbot():
+        answer = skynet.answer(question)
+        print(f"Chatbot: {answer}")
+    else:
+        answer = "Chatbot deshabilitado durante desarrollo."
 
     return {"answer": answer}

--- a/Backend/app/api.py
+++ b/Backend/app/api.py
@@ -2,9 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from app.ai.chatbot import Skynet
 from app.ai.chatbot_router import router as chatbot_router
-from app.ai.topics import Topics
 from app.database import initialize_database
 from app.server_config import ServerConfig
 from app.user.user_router import router as user_router
@@ -15,8 +13,6 @@ class QuestionRequest(BaseModel):
 
 
 server_config = ServerConfig()
-topics = Topics()
-skynet = Skynet(topics)
 
 app = FastAPI()
 

--- a/Backend/app/api.py
+++ b/Backend/app/api.py
@@ -6,6 +6,7 @@ from app.ai.chatbot_router import router as chatbot_router
 from app.database import initialize_database
 from app.server_config import ServerConfig
 from app.user.user_router import router as user_router
+from app.file_paths import DATABASE_PATH
 
 
 class QuestionRequest(BaseModel):
@@ -28,4 +29,4 @@ app.add_middleware(
 app.include_router(chatbot_router)
 app.include_router(user_router)
 
-initialize_database()
+initialize_database(DATABASE_PATH)

--- a/Backend/app/database.py
+++ b/Backend/app/database.py
@@ -1,15 +1,15 @@
-import os
+from pathlib import Path
 import sqlite3
 from typing import Any
 
-DATABASE_PATH = "sqlite.db"
+from app.file_paths import DATABASE_PATH
 
 
-def initialize_database():
-    if not os.path.exists(DATABASE_PATH):
-        open(DATABASE_PATH, "a").close()
+def initialize_database(db_path: Path) -> None:
+    if not db_path.exists():
+        open(db_path, "a").close()
 
-    conn = sqlite3.connect(DATABASE_PATH)
+    conn = sqlite3.connect(db_path)
     c = conn.cursor()
     c.execute(
         """CREATE TABLE IF NOT EXISTS users
@@ -33,9 +33,11 @@ def initialize_database():
     conn.close()
 
 
-def query_database(query: str, args: tuple[Any]) -> list[Any]:
+def query_database(
+    query: str, args: tuple[Any], db_path: Path = DATABASE_PATH
+) -> list[Any]:
     try:
-        conn = sqlite3.connect(DATABASE_PATH)
+        conn = sqlite3.connect(db_path)
         c = conn.cursor()
         c.execute(query, args)
         data = c.fetchone()
@@ -44,9 +46,11 @@ def query_database(query: str, args: tuple[Any]) -> list[Any]:
         conn.close()
 
 
-def execute_in_database(command: str, args: tuple[Any]) -> None:
+def execute_in_database(
+    command: str, args: tuple[Any], db_path: Path = DATABASE_PATH
+) -> None:
     try:
-        conn = sqlite3.connect(DATABASE_PATH)
+        conn = sqlite3.connect(db_path)
 
         with conn:
             conn.execute(command, args)

--- a/Backend/app/database.py
+++ b/Backend/app/database.py
@@ -4,40 +4,42 @@ from typing import Any
 
 from app.file_paths import DATABASE_PATH
 
+default_database = DATABASE_PATH
+
 
 def initialize_database(db_path: Path) -> None:
     if not db_path.exists():
         open(db_path, "a").close()
 
-    conn = sqlite3.connect(db_path)
-    c = conn.cursor()
-    c.execute(
-        """CREATE TABLE IF NOT EXISTS users
-                 (id INTEGER PRIMARY KEY AUTOINCREMENT,
-                  firstName TEXT,
-                  lastName TEXT,
-                  email TEXT UNIQUE,
-                  password TEXT,
-                  challengeKey TEXT,
-                  dni TEXT)"""
-    )
-    c.execute(
-        """CREATE TABLE IF NOT EXISTS deviceRSAS
-                 (id INTEGER PRIMARY KEY AUTOINCREMENT,
-                  email TEXT,
-                  deviceUID INTEGER,
-                  publicRSA TEXT,
-                  UNIQUE(email, deviceUID))"""
-    )
-    conn.commit()
-    conn.close()
-
-
-def query_database(
-    query: str, args: tuple[Any], db_path: Path = DATABASE_PATH
-) -> list[Any]:
     try:
         conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+        c.execute(
+            """CREATE TABLE IF NOT EXISTS users
+                    (id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    firstName TEXT,
+                    lastName TEXT,
+                    email TEXT UNIQUE,
+                    password TEXT,
+                    challengeKey TEXT,
+                    dni TEXT)"""
+        )
+        c.execute(
+            """CREATE TABLE IF NOT EXISTS deviceRSAS
+                    (id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    email TEXT,
+                    deviceUID INTEGER,
+                    publicRSA TEXT,
+                    UNIQUE(email, deviceUID))"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def query_database(query: str, args: tuple[Any]) -> list[Any]:
+    try:
+        conn = sqlite3.connect(default_database)
         c = conn.cursor()
         c.execute(query, args)
         data = c.fetchone()
@@ -46,13 +48,11 @@ def query_database(
         conn.close()
 
 
-def execute_in_database(
-    command: str, args: tuple[Any], db_path: Path = DATABASE_PATH
-) -> None:
+def execute_in_database(command: str, args: tuple[Any]) -> None:
     try:
-        conn = sqlite3.connect(db_path)
+        conn = sqlite3.connect(default_database)
 
         with conn:
             conn.execute(command, args)
     finally:
-        conn.close
+        conn.close()

--- a/Backend/app/file_paths.py
+++ b/Backend/app/file_paths.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 APP_DIR = Path(".") / "app"
 
+DATABASE_PATH = Path(".") / "sqlite.db"
+TEST_DB_PATH = Path(".") / "testing.db"
+
 CONFIG_FILE = APP_DIR / "server_config.json"
 
 DATA_DIR = APP_DIR / "ai" / "data"

--- a/Backend/app/server_config.json.example
+++ b/Backend/app/server_config.json.example
@@ -2,5 +2,6 @@
     "request_origins": ["*"],
     "server_ip": "0.0.0.0",
     "server_port": 8080,
+    "using_chatbot": false,
     "jwt_secret": "secret"
 }

--- a/Backend/app/server_config.py
+++ b/Backend/app/server_config.py
@@ -17,6 +17,9 @@ class ServerConfig:
     def get_server_port(self) -> int:
         return self._configs["server_port"]
 
+    def is_using_chatbot(self) -> bool:
+        return self._configs["using_chatbot"]
+
     def get_jwt_secret(self) -> int:
         return self._configs["jwt_secret"]
 

--- a/Backend/app/user/user_service.py
+++ b/Backend/app/user/user_service.py
@@ -70,7 +70,7 @@ def get_user_by_email(email: str) -> User:
         return user
 
 
-def update_public_rsa(user_email: str, public_rsa: str, device_uid: str):
+def update_public_rsa(user_email: str, public_rsa: str, device_uid: int):
 
     if device_rsa_exists(user_email, device_uid):
         update_existing_public_rsa(user_email, public_rsa, device_uid)
@@ -78,7 +78,7 @@ def update_public_rsa(user_email: str, public_rsa: str, device_uid: str):
         create_new_public_rsa(user_email, public_rsa, device_uid)
 
 
-def device_rsa_exists(user_email: str, device_uid: str) -> bool:
+def device_rsa_exists(user_email: str, device_uid: int) -> bool:
     device_rsa = query_database(
         """SELECT * FROM deviceRSAS WHERE email = ? AND deviceUID = ?""",
         (user_email, device_uid),
@@ -87,7 +87,7 @@ def device_rsa_exists(user_email: str, device_uid: str) -> bool:
     return bool(device_rsa)
 
 
-def update_existing_public_rsa(user_email: str, public_rsa: str, device_uid: str):
+def update_existing_public_rsa(user_email: str, public_rsa: str, device_uid: int):
 
     execute_in_database(
         """UPDATE deviceRSAS SET publicRSA = ? WHERE email = ? AND deviceUID = ?""",
@@ -95,7 +95,7 @@ def update_existing_public_rsa(user_email: str, public_rsa: str, device_uid: str
     )
 
 
-def create_new_public_rsa(user_email: str, public_rsa: str, device_uid: str):
+def create_new_public_rsa(user_email: str, public_rsa: str, device_uid: int):
 
     execute_in_database(
         """INSERT INTO deviceRSAS (email, deviceUID, publicRSA)
@@ -104,7 +104,7 @@ def create_new_public_rsa(user_email: str, public_rsa: str, device_uid: str):
     )
 
 
-def get_public_rsa(user_email: str, device_uid: str) -> str | None:
+def get_public_rsa(user_email: str, device_uid: int) -> str | None:
     deviceRSA = query_database(
         """SELECT * FROM deviceRSAS WHERE email = ? AND deviceUID = ?""",
         (user_email, device_uid),
@@ -125,6 +125,7 @@ def generate_new_uid(user_email: str):
     if latest_user_device[0] is not None:
         result["deviceUID"] = latest_user_device[0] + 1
 
+    print(result)
     return result
 
 
@@ -144,7 +145,7 @@ def delete_challenge(email: str):
     )
 
 
-def verify_challenge(user: User, device_uid: str, encrypted_text: list[int]):
+def verify_challenge(user: User, device_uid: int, encrypted_text: list[int]):
     user_rsa = get_public_rsa(user.email, device_uid)
 
     if user_rsa is None:

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -1,21 +1,14 @@
 import uvicorn
 
-from app.ai.trainer import train
 from app.server_config import ServerConfig
 
 if __name__ == "__main__":
-    action = input(
-        "\n ------------------ \n0) Start server. \n1) Train model.\nSelect action: "
+
+    server_config = ServerConfig()
+
+    uvicorn.run(
+        "app.api:app",
+        host=server_config.get_server_ip(),
+        port=server_config.get_server_port(),
+        reload=False,
     )
-
-    if action == "1":
-        train()
-    else:
-        server_config = ServerConfig()
-
-        uvicorn.run(
-            "app.api:app",
-            host=server_config.get_server_ip(),
-            port=server_config.get_server_port(),
-            reload=False,
-        )

--- a/Backend/tests/common_fixtures.py
+++ b/Backend/tests/common_fixtures.py
@@ -1,0 +1,16 @@
+import pytest
+
+from app import database
+from app.file_paths import TEST_DB_PATH
+
+
+@pytest.fixture
+def db_path():
+    """Initializes a test database and deletes it after the test is finished."""
+    database.initialize_database(TEST_DB_PATH)
+    try:
+        database.default_database = TEST_DB_PATH
+
+        yield TEST_DB_PATH
+    finally:
+        TEST_DB_PATH.unlink()

--- a/Backend/tests/test_user_service.py
+++ b/Backend/tests/test_user_service.py
@@ -1,0 +1,136 @@
+import pytest
+
+from app.user.user_dtos import CreateUserDTO
+from app import database
+from app.user import user_service
+from app.file_paths import TEST_DB_PATH
+
+
+# IMPORTANT: the `db_path` fixture handles initializing and then deleting the test db.
+# Make sure to use it in your tests that rely on a database even if you won't use the `db_path` path itself.
+
+
+def test_user_is_created(db_path, user_1):
+    user_service.create_user(user_1)
+
+    user_in_db = user_service.get_user_by_email(user_1.email)
+
+    assert user_in_db.firstName == "Joaquin"
+
+
+def test_repeated_email_causes_error(db_path, user_1):
+    user_service.create_user(user_1)
+
+    user2 = user_1
+    user2.firstName = "Manuel"
+    user2.lastName = "Rodriguez"
+
+    result = user_service.create_user(user2)
+
+    assert result["error"] == "El email ya está registrado"
+
+
+def test_repeated_user_creation_causes_error(db_path, user_1):
+    user_service.create_user(user_1)
+
+    result = user_service.create_user(user_1)
+
+    assert result["error"] == "El email ya está registrado"
+
+
+def test_authenticating_user(db_path, user_1):
+    user_service.create_user(user_1)
+
+    result = user_service.authenticate_user("enriquez_test@gmail.com", "123456")
+
+    assert result["firstName"] == "Joaquin"
+
+
+def test_wrong_password_doesnt_auth(db_path, user_1):
+    user_service.create_user(user_1)
+
+    result = user_service.authenticate_user("enriquez_test@gmail.com", "wrong")
+
+    assert result is None
+
+
+def test_wrong_email_doesnt_auth(db_path, user_1):
+    user_service.create_user(user_1)
+
+    result = user_service.authenticate_user("enriquez_wrong@gmail.com", "123456")
+
+    assert result is None
+
+
+def test_create_new_rsa(db_path, user_1, public_key_1):
+    user_service.create_user(user_1)
+
+    user_service.update_public_rsa(user_1.email, public_key_1, 0)
+
+    assert user_service.get_public_rsa(user_1.email, 0) == public_key_1
+
+
+def test_wrong_device_uid_doesnt_exist(db_path, user_1, public_key_1):
+    user_service.create_user(user_1)
+
+    user_service.update_public_rsa(user_1.email, public_key_1, 0)
+
+    assert not user_service.device_rsa_exists(user_1.email, 1)
+
+
+def test_rsa_is_updated(db_path, user_1, public_key_1, public_key_2):
+    user_service.create_user(user_1)
+    user_service.update_public_rsa(user_1.email, public_key_1, 0)
+
+    user_service.update_public_rsa(user_1.email, public_key_2, 0)
+
+    assert user_service.get_public_rsa(user_1.email, 0) == public_key_2
+
+
+def test_generate_new_uid_without_any_previous_uids(db_path, user_1):
+    user_service.create_user(user_1)
+
+    assert user_service.generate_new_uid(user_1.email) == {"deviceUID": 0}
+
+
+def test_generate_new_uid_with_a_previous_uid(
+    db_path, user_1, public_key_1, public_key_2
+):
+    user_service.create_user(user_1)
+    user_service.update_public_rsa(user_1.email, public_key_1, 0)
+
+    assert user_service.generate_new_uid(user_1.email) == {"deviceUID": 1}
+
+
+@pytest.fixture
+def db_path():
+    """Initializes a test database and deletes it after the test is finished."""
+    database.initialize_database(TEST_DB_PATH)
+    try:
+        database.default_database = TEST_DB_PATH
+
+        yield TEST_DB_PATH
+    finally:
+        TEST_DB_PATH.unlink()
+
+
+@pytest.fixture
+def user_1():
+    """Creates CreateUserDTO of User "Joaquin Enriquez"."""
+
+    return CreateUserDTO(
+        firstName="Joaquin",
+        lastName="Enriquez",
+        email="enriquez_test@gmail.com",
+        password="123456",
+    )
+
+
+@pytest.fixture
+def public_key_1():
+    return '{"e":5,"n":7663}'
+
+
+@pytest.fixture
+def public_key_2():
+    return '{"e":7,"n":3599}'

--- a/Backend/tests/test_user_service.py
+++ b/Backend/tests/test_user_service.py
@@ -5,6 +5,8 @@ from app import database
 from app.user import user_service
 from app.file_paths import TEST_DB_PATH
 
+from tests.common_fixtures import db_path
+
 
 # IMPORTANT: the `db_path` fixture handles initializing and then deleting the test db.
 # Make sure to use it in your tests that rely on a database even if you won't use the `db_path` path itself.
@@ -100,18 +102,6 @@ def test_generate_new_uid_with_a_previous_uid(
     user_service.update_public_rsa(user_1.email, public_key_1, 0)
 
     assert user_service.generate_new_uid(user_1.email) == {"deviceUID": 1}
-
-
-@pytest.fixture
-def db_path():
-    """Initializes a test database and deletes it after the test is finished."""
-    database.initialize_database(TEST_DB_PATH)
-    try:
-        database.default_database = TEST_DB_PATH
-
-        yield TEST_DB_PATH
-    finally:
-        TEST_DB_PATH.unlink()
 
 
 @pytest.fixture


### PR DESCRIPTION
IMPORTANT: the `db_path` fixture handles initializing and then deleting the test db.
Make sure to use it in your tests that rely on a database even if you won't use the `db_path` path itself.

IMPORTANT: the `server_config.json.example` was modified, make sure that your local `server_config.json` is updated accordingly.

* Allows disabling the chatbot for development. Importing tensorflow and loading the chatbot model can take a couple of seconds, which can get annoying fast considering we aren't prioritizing working on this feature for the foreseeable future. Now you can just disable this from the server config.
* Adds some initial unit tests for the user_service.